### PR TITLE
Release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] (March 2022)
+### Added
+- add minimum customer info (name and email) to all payments
+
+### Changed
+- use short id as transaction id in payment history (WaWi)
+
+### Fixed
+- set default db engine and charset when creating database tables to avoid issues due to weird defaults
+- add error handling to avoid issues in the frontend when API is not callable *(ie missing keys)*
+- fix issue with -0.0 beeing interpreted as negative in the unzer api
+- potential fix for mismatch of order ids between the unzer insight portal and the shop
+- error in the placeholder of the public key setting in the backend
+
 ## [1.0.1] (November 2021)
 ### Added
 - JTL Shop 5.1 Compatability
@@ -18,5 +32,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 - Initial Release
 
+[1.0.2]: https://github.com/unzerdev/jtl5/compare/1.0.1...1.0.2
 [1.0.1]: https://github.com/unzerdev/jtl5/compare/1.0.0...1.0.1
 [1.0.0]: https://github.com/unzerdev/jtl5

--- a/Migrations/Migration20201027083900.php
+++ b/Migrations/Migration20201027083900.php
@@ -22,7 +22,7 @@ class Migration20201027083900 extends Migration implements IMigration
         $this->execute('CREATE TABLE IF NOT EXISTS ' . Config::TABLE . ' (
             `key` VARCHAR(255) NOT NULL PRIMARY KEY,
             `value` VARCHAR(255) NOT NULL
-        );');
+        ) ENGINE=InnoDB CHARSET=utf8 COLLATE utf8_unicode_ci;');
 
         // Create Order Mapping Table
         $this->execute(
@@ -36,7 +36,7 @@ class Migration20201027083900 extends Migration implements IMigration
                 `payment_type_name` VARCHAR(255),   /* payment type name from heidelpay */
                 `payment_type_id` VARCHAR(255),     /* payment type id from heidelpay */
                 PRIMARY KEY (`jtl_order_id`, `payment_id`)
-            );'
+            ) ENGINE=InnoDB CHARSET=utf8 COLLATE utf8_unicode_ci;'
         );
 
         // Create Charge Mapping Table
@@ -46,7 +46,7 @@ class Migration20201027083900 extends Migration implements IMigration
                 `order_id`  INT(10) NOT NULL,    /* jtl order table id (kBestellung) */
                 `charge_id` VARCHAR(255),        /* charge id from heidelpay */
                 `payment_id` VARCHAR(255)       /* payment id from heidelpay */
-            );'
+            ) ENGINE=InnoDB CHARSET=utf8 COLLATE utf8_unicode_ci;'
         );
     }
 

--- a/adminmenu/template/settings.tpl
+++ b/adminmenu/template/settings.tpl
@@ -30,7 +30,7 @@
                                 <label for="hpSettings-publicKey">{__('hpSettingsPublicKeyLabel')}</label>
                             </div>
                             <div class="hp-admin-option__input col-xs-9 col-9">
-                                <input type="text" class="form-control" name="publicKey" id="hpSettings-publicKey" placeholder="{_('hpSettingsPublicKeyPlaceholder')}" value="{if isset($hpSettings.config.publicKey)}{$hpSettings.config.publicKey}{/if}" />
+                                <input type="text" class="form-control" name="publicKey" id="hpSettings-publicKey" placeholder="{__('hpSettingsPublicKeyPlaceholder')}" value="{if isset($hpSettings.config.publicKey)}{$hpSettings.config.publicKey}{/if}" />
                                 <small class="form-text help-block text-muted">{__('hpSettingsPublicKeyHelp')}</small>
                             </div>
                         </div>

--- a/info.xml
+++ b/info.xml
@@ -6,7 +6,7 @@
     <URL>http://www.solution360.de</URL>
     <XMLVersion>100</XMLVersion>
     <MinShopVersion>5.0.0</MinShopVersion>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <PluginID>s360_unzer_shop5</PluginID>
     <CreateDate>2020-10-27</CreateDate>
     <ExsID>eef84f33-97ff-4519-8e0f-6760ae06c51f</ExsID>

--- a/paymentmethod/HeidelpayAlipay.php
+++ b/paymentmethod/HeidelpayAlipay.php
@@ -8,6 +8,7 @@ use UnzerSDK\Resources\TransactionTypes\AbstractTransactionType;
 use UnzerSDK\Resources\TransactionTypes\Charge;
 use Plugin\s360_unzer_shop5\src\Payments\HeidelpayPaymentMethod;
 use Plugin\s360_unzer_shop5\src\Payments\Interfaces\RedirectPaymentInterface;
+use Plugin\s360_unzer_shop5\src\Payments\Traits\HasCustomer;
 use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 
 /**
@@ -26,6 +27,7 @@ use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 class HeidelpayAlipay extends HeidelpayPaymentMethod implements RedirectPaymentInterface
 {
     use HasMetadata;
+    use HasCustomer;
 
     /**
      * @inheritDoc
@@ -33,12 +35,19 @@ class HeidelpayAlipay extends HeidelpayPaymentMethod implements RedirectPaymentI
      */
     protected function performTransaction(BasePaymentType $payment, $order): AbstractTransactionType
     {
+        // Create / Update existing customer resource if needed
+        $customer = $this->createOrFetchHeidelpayCustomer($this->adapter, $this->sessionHelper, false);
+
+        if ($customer->getId()) {
+            $customer = $this->adapter->getApi()->updateCustomer($customer);
+        }
+
         return $this->adapter->getApi()->charge(
             $this->getTotalPriceCustomerCurrency($order),
             $order->Waehrung->cISO,
             $payment->getId(),
             $this->getReturnURL($order),
-            null,
+            $customer,
             $order->cBestellNr ?? null,
             $this->createMetadata()
         );

--- a/paymentmethod/HeidelpayEPS.php
+++ b/paymentmethod/HeidelpayEPS.php
@@ -8,6 +8,7 @@ use UnzerSDK\Resources\TransactionTypes\AbstractTransactionType;
 use UnzerSDK\Resources\TransactionTypes\Charge;
 use Plugin\s360_unzer_shop5\src\Payments\HeidelpayPaymentMethod;
 use Plugin\s360_unzer_shop5\src\Payments\Interfaces\RedirectPaymentInterface;
+use Plugin\s360_unzer_shop5\src\Payments\Traits\HasCustomer;
 use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 
 /**
@@ -26,6 +27,7 @@ use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 class HeidelpayEPS extends HeidelpayPaymentMethod implements RedirectPaymentInterface
 {
     use HasMetadata;
+    use HasCustomer;
 
     /**
      * @inheritDoc
@@ -33,12 +35,19 @@ class HeidelpayEPS extends HeidelpayPaymentMethod implements RedirectPaymentInte
      */
     protected function performTransaction(BasePaymentType $payment, $order): AbstractTransactionType
     {
+        // Create / Update existing customer resource if needed
+        $customer = $this->createOrFetchHeidelpayCustomer($this->adapter, $this->sessionHelper, false);
+
+        if ($customer->getId()) {
+            $customer = $this->adapter->getApi()->updateCustomer($customer);
+        }
+
         return $this->adapter->getApi()->charge(
             $this->getTotalPriceCustomerCurrency($order),
             $order->Waehrung->cISO,
             $payment->getId(),
             $this->getReturnURL($order),
-            null,
+            $customer,
             $order->cBestellNr ?? null,
             $this->createMetadata()
         );

--- a/paymentmethod/HeidelpayFlexiPayDirect.php
+++ b/paymentmethod/HeidelpayFlexiPayDirect.php
@@ -8,6 +8,7 @@ use UnzerSDK\Resources\TransactionTypes\AbstractTransactionType;
 use UnzerSDK\Resources\TransactionTypes\Charge;
 use Plugin\s360_unzer_shop5\src\Payments\HeidelpayPaymentMethod;
 use Plugin\s360_unzer_shop5\src\Payments\Interfaces\RedirectPaymentInterface;
+use Plugin\s360_unzer_shop5\src\Payments\Traits\HasCustomer;
 use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 
 /**
@@ -26,6 +27,7 @@ use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 class HeidelpayFlexiPayDirect extends HeidelpayPaymentMethod implements RedirectPaymentInterface
 {
     use HasMetadata;
+    use HasCustomer;
 
     /**
      * @inheritDoc
@@ -33,12 +35,19 @@ class HeidelpayFlexiPayDirect extends HeidelpayPaymentMethod implements Redirect
      */
     protected function performTransaction(BasePaymentType $payment, $order): AbstractTransactionType
     {
+        // Create / Update existing customer resource if needed
+        $customer = $this->createOrFetchHeidelpayCustomer($this->adapter, $this->sessionHelper, false);
+
+        if ($customer->getId()) {
+            $customer = $this->adapter->getApi()->updateCustomer($customer);
+        }
+
         return $this->adapter->getApi()->charge(
             $this->getTotalPriceCustomerCurrency($order),
             $order->Waehrung->cISO,
             $payment->getId(),
             $this->getReturnURL($order),
-            null,
+            $customer,
             $order->cBestellNr ?? null,
             $this->createMetadata()
         );

--- a/paymentmethod/HeidelpayGiropay.php
+++ b/paymentmethod/HeidelpayGiropay.php
@@ -8,6 +8,7 @@ use UnzerSDK\Resources\TransactionTypes\AbstractTransactionType;
 use UnzerSDK\Resources\TransactionTypes\Charge;
 use Plugin\s360_unzer_shop5\src\Payments\HeidelpayPaymentMethod;
 use Plugin\s360_unzer_shop5\src\Payments\Interfaces\RedirectPaymentInterface;
+use Plugin\s360_unzer_shop5\src\Payments\Traits\HasCustomer;
 use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 
 /**
@@ -24,6 +25,7 @@ use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 class HeidelpayGiropay extends HeidelpayPaymentMethod implements RedirectPaymentInterface
 {
     use HasMetadata;
+    use HasCustomer;
 
     /**
      * @inheritDoc
@@ -31,12 +33,19 @@ class HeidelpayGiropay extends HeidelpayPaymentMethod implements RedirectPayment
      */
     protected function performTransaction(BasePaymentType $payment, $order): AbstractTransactionType
     {
+        // Create / Update existing customer resource if needed
+        $customer = $this->createOrFetchHeidelpayCustomer($this->adapter, $this->sessionHelper, false);
+
+        if ($customer->getId()) {
+            $customer = $this->adapter->getApi()->updateCustomer($customer);
+        }
+
         return $this->adapter->getApi()->charge(
             $this->getTotalPriceCustomerCurrency($order),
             $order->Waehrung->cISO,
             $payment->getId(),
             $this->getReturnURL($order),
-            null,
+            $customer,
             $order->cBestellNr ?? null,
             $this->createMetadata()
         );

--- a/paymentmethod/HeidelpayPrepayment.php
+++ b/paymentmethod/HeidelpayPrepayment.php
@@ -10,6 +10,7 @@ use JTL\Checkout\Bestellung;
 use JTL\Checkout\ZahlungsInfo;
 use JTL\Helpers\Text;
 use Plugin\s360_unzer_shop5\src\Payments\HeidelpayPaymentMethod;
+use Plugin\s360_unzer_shop5\src\Payments\Traits\HasCustomer;
 use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 
 /**
@@ -29,6 +30,7 @@ use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 class HeidelpayPrepayment extends HeidelpayPaymentMethod
 {
     use HasMetadata;
+    use HasCustomer;
 
     /**
      * Data the merchant needs to put on the Invoice.
@@ -72,12 +74,19 @@ class HeidelpayPrepayment extends HeidelpayPaymentMethod
      */
     protected function performTransaction(BasePaymentType $payment, $order): AbstractTransactionType
     {
+        // Create / Update existing customer resource if needed
+        $customer = $this->createOrFetchHeidelpayCustomer($this->adapter, $this->sessionHelper, false);
+
+        if ($customer->getId()) {
+            $customer = $this->adapter->getApi()->updateCustomer($customer);
+        }
+
         return $this->adapter->getApi()->charge(
             $this->getTotalPriceCustomerCurrency($order),
             $order->Waehrung->cISO,
             $payment->getId(),
             $this->getReturnURL($order),
-            null,
+            $customer,
             $order->cBestellNr ?? null,
             $this->createMetadata()
         );

--- a/paymentmethod/HeidelpaySofort.php
+++ b/paymentmethod/HeidelpaySofort.php
@@ -8,6 +8,7 @@ use UnzerSDK\Resources\TransactionTypes\AbstractTransactionType;
 use UnzerSDK\Resources\TransactionTypes\Charge;
 use Plugin\s360_unzer_shop5\src\Payments\HeidelpayPaymentMethod;
 use Plugin\s360_unzer_shop5\src\Payments\Interfaces\RedirectPaymentInterface;
+use Plugin\s360_unzer_shop5\src\Payments\Traits\HasCustomer;
 use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 
 /**
@@ -28,6 +29,7 @@ use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 class HeidelpaySofort extends HeidelpayPaymentMethod implements RedirectPaymentInterface
 {
     use HasMetadata;
+    use HasCustomer;
 
     /**
      * @inheritDoc
@@ -35,12 +37,19 @@ class HeidelpaySofort extends HeidelpayPaymentMethod implements RedirectPaymentI
      */
     protected function performTransaction(BasePaymentType $payment, $order): AbstractTransactionType
     {
+        // Create / Update existing customer resource if needed
+        $customer = $this->createOrFetchHeidelpayCustomer($this->adapter, $this->sessionHelper, false);
+
+        if ($customer->getId()) {
+            $customer = $this->adapter->getApi()->updateCustomer($customer);
+        }
+
         return $this->adapter->getApi()->charge(
             $this->getTotalPriceCustomerCurrency($order),
             $order->Waehrung->cISO,
             $payment->getId(),
             $this->getReturnURL($order),
-            null,
+            $customer,
             $order->cBestellNr ?? null,
             $this->createMetadata()
         );

--- a/paymentmethod/HeidelpayWeChatPay.php
+++ b/paymentmethod/HeidelpayWeChatPay.php
@@ -8,6 +8,7 @@ use UnzerSDK\Resources\TransactionTypes\AbstractTransactionType;
 use UnzerSDK\Resources\TransactionTypes\Charge;
 use Plugin\s360_unzer_shop5\src\Payments\HeidelpayPaymentMethod;
 use Plugin\s360_unzer_shop5\src\Payments\Interfaces\RedirectPaymentInterface;
+use Plugin\s360_unzer_shop5\src\Payments\Traits\HasCustomer;
 use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 
 /**
@@ -23,6 +24,7 @@ use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 class HeidelpayWeChatPay extends HeidelpayPaymentMethod implements RedirectPaymentInterface
 {
     use HasMetadata;
+    use HasCustomer;
 
     /**
      * @inheritDoc
@@ -30,12 +32,19 @@ class HeidelpayWeChatPay extends HeidelpayPaymentMethod implements RedirectPayme
      */
     protected function performTransaction(BasePaymentType $payment, $order): AbstractTransactionType
     {
+        // Create / Update existing customer resource if needed
+        $customer = $this->createOrFetchHeidelpayCustomer($this->adapter, $this->sessionHelper, false);
+
+        if ($customer->getId()) {
+            $customer = $this->adapter->getApi()->updateCustomer($customer);
+        }
+
         return $this->adapter->getApi()->charge(
             $this->getTotalPriceCustomerCurrency($order),
             $order->Waehrung->cISO,
             $payment->getId(),
             $this->getReturnURL($order),
-            null,
+            $customer,
             $order->cBestellNr ?? null,
             $this->createMetadata()
         );

--- a/paymentmethod/HeidelpayiDEAL.php
+++ b/paymentmethod/HeidelpayiDEAL.php
@@ -8,6 +8,7 @@ use UnzerSDK\Resources\TransactionTypes\AbstractTransactionType;
 use UnzerSDK\Resources\TransactionTypes\Charge;
 use Plugin\s360_unzer_shop5\src\Payments\HeidelpayPaymentMethod;
 use Plugin\s360_unzer_shop5\src\Payments\Interfaces\RedirectPaymentInterface;
+use Plugin\s360_unzer_shop5\src\Payments\Traits\HasCustomer;
 use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 
 /**
@@ -29,6 +30,7 @@ use Plugin\s360_unzer_shop5\src\Payments\Traits\HasMetadata;
 class HeidelpayiDEAL extends HeidelpayPaymentMethod implements RedirectPaymentInterface
 {
     use HasMetadata;
+    use HasCustomer;
 
     /**
      * @inheritDoc
@@ -36,12 +38,19 @@ class HeidelpayiDEAL extends HeidelpayPaymentMethod implements RedirectPaymentIn
      */
     protected function performTransaction(BasePaymentType $payment, $order): AbstractTransactionType
     {
+        // Create / Update existing customer resource if needed
+        $customer = $this->createOrFetchHeidelpayCustomer($this->adapter, $this->sessionHelper, false);
+
+        if ($customer->getId()) {
+            $customer = $this->adapter->getApi()->updateCustomer($customer);
+        }
+
         return $this->adapter->getApi()->charge(
             $this->getTotalPriceCustomerCurrency($order),
             $order->Waehrung->cISO,
             $payment->getId(),
             $this->getReturnURL($order),
-            null,
+            $customer,
             $order->cBestellNr ?? null,
             $this->createMetadata()
         );

--- a/src/Charges/ChargeHandler.php
+++ b/src/Charges/ChargeHandler.php
@@ -54,7 +54,8 @@ class ChargeHandler
             $paymentMethod->addIncomingPayment($order, (object) [
                 'fBetrag'  => $charge->getAmount(),
                 'cISO'     => $charge->getCurrency(),
-                'cHinweis' => $charge->getUniqueId() ?? $charge->getPaymentId() ?? $charge->getId()
+                'cHinweis' => $charge->getShortId() ?? $charge->getUniqueId()
+                                ?? $charge->getPaymentId() ?? $charge->getId()
             ]);
 
             // Save Charge in mapping table

--- a/src/Payments/HeidelpayApiAdapter.php
+++ b/src/Payments/HeidelpayApiAdapter.php
@@ -11,6 +11,7 @@ use UnzerSDK\Resources\PaymentTypes\InvoiceSecured;
 use UnzerSDK\Resources\TransactionTypes\AbstractTransactionType;
 use UnzerSDK\Resources\TransactionTypes\Authorization;
 use JTL\Cart\Cart;
+use JTL\Checkout\Bestellung;
 use JTL\Helpers\Text;
 use Plugin\s360_unzer_shop5\src\Utils\Config;
 use Plugin\s360_unzer_shop5\src\Utils\JtlLinkHelper;
@@ -188,11 +189,16 @@ class HeidelpayApiAdapter
      *
      * @SuppressWarnings(PHPMD.ExitExpression)
      * @param AbstractTransactionType $transaction
+     * @param Bestellung $order
      * @param array $postData
      * @return void
      */
-    public function redirectTransaction(AbstractTransactionType $transaction, array $postData = []): void
-    {
+    public function redirectTransaction(
+        AbstractTransactionType $transaction,
+        Bestellung $order,
+        array $postData = []
+    ): void {
+        $this->session->set(SessionHelper::KEY_ORDER_ID, $order->cBestellNr);
         $this->session->set(SessionHelper::KEY_PAYMENT_ID, $transaction->getPaymentId());
         $this->session->set(SessionHelper::KEY_SHORT_ID, $transaction->getShortId());
         $this->session->set(SessionHelper::KEY_CONFIRM_POST_ARRAY, $postData);

--- a/src/Payments/Traits/HasBasket.php
+++ b/src/Payments/Traits/HasBasket.php
@@ -98,6 +98,11 @@ trait HasBasket
         $cumulatedDelta    += ($grossAmount - $roundedGrossAmount);
         $cumulatedDeltaNet += ($netAmount - $roundedNetAmount);
 
+        // Unzer API thinks that -0.0 is a negative amount and therefore not allowed (seen for SEPA secured and B2B)
+        if ($roundedNetAmount === -0.0) {
+            $roundedNetAmount = 0;
+        }
+
         // Set Basket Item
         $basketItem = new BasketItem(
             Text::convertUTF8($title),

--- a/src/Utils/SessionHelper.php
+++ b/src/Utils/SessionHelper.php
@@ -19,6 +19,7 @@ class SessionHelper
 {
     use JtlLoggerTrait;
 
+    public const KEY_ORDER_ID = 'orderId';
     public const KEY_RESOURCE_ID = 'resourceId';
     public const KEY_CART_CHECKSUM = 'cartChecksum';
     public const KEY_CHECKOUT_SESSION = 'checkoutSession';


### PR DESCRIPTION
### Added
- add minimum customer info (name and email) to all payments

### Changed
- use short id as transaction id in payment history (WaWi)

### Fixed
- set default db engine and charset when creating database tables to avoid issues due to weird defaults
- add error handling to avoid issues in the frontend when API is not callable *(ie missing keys)*
- fix issue with -0.0 beeing interpreted as negative in the unzer api
- potential fix for mismatch of order ids between the unzer insight portal and the shop
- error in the placeholder of the public key setting in the backend